### PR TITLE
reformat & bugfix when set custom headers in SessionWithHeaders

### DIFF
--- a/tests/resources_test.py
+++ b/tests/resources_test.py
@@ -35,13 +35,14 @@ if not os.environ.get("PYTHON_YADISK_APP_TOKEN"):
 if not os.environ.get("PYTHON_YADISK_TEST_ROOT"):
     raise ValueError("Environment variable PYTHON_YADISK_TEST_ROOT must be set")
 
+
 def async_test(f):
     def wrapper(*args, **kwargs):
-        coroutine = asyncio.coroutine(f)
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(coroutine(*args, **kwargs))
+        loop.run_until_complete(f(*args, **kwargs))
 
     return wrapper
+
 
 class ResourcesTestCase(TestCase):
     def __init__(self, *args, **kwargs):
@@ -64,7 +65,7 @@ class ResourcesTestCase(TestCase):
 
     @async_test
     async def test_get_meta(self):
-       self.assertIsInstance(await self.yadisk.get_meta(self.path), yadisk_async.objects.ResourceObject)
+        self.assertIsInstance(await self.yadisk.get_meta(self.path), yadisk_async.objects.ResourceObject)
 
     def test_listdir(self):
         names = ["dir1", "dir2", "dir3"]

--- a/yadisk_async/session.py
+++ b/yadisk_async/session.py
@@ -11,15 +11,17 @@ DEFAULT_USER_AGENT = "Python/%s.%s aiohttp/%s" % (sys.version_info.major,
                                                   sys.version_info.minor,
                                                   aiohttp.__version__)
 
+
 class SessionWithHeaders(aiohttp.ClientSession):
     """Just like your regular :any:`aiohttp.ClientSession` but with headers"""
 
     def __init__(self, *args, **kwargs):
         aiohttp.ClientSession.__init__(self, *args, **kwargs)
 
-        self.headers = CaseInsensitiveDict({
+        self.headers.update(CaseInsensitiveDict({
             "User-Agent": DEFAULT_USER_AGENT,
             "Accept-Encoding": ", ".join(("gzip", "deflate")),
             "Accept": "*/*",
             "Connection": "keep-alive"
-        })
+        }))
+


### PR DESCRIPTION
reformat resources_test.py:
asyncio.coroutine is Deprecated since version 3.8

bugfix session.py:
set custom header in parent class aiohttp.ClientSession in constructor of SessionWithHeaders class