### PR TITLE
Добавлены два параметра в функцию upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+aiofiles

--- a/yadisk_async/yadisk.py
+++ b/yadisk_async/yadisk.py
@@ -346,6 +346,12 @@ class YaDisk(object):
             :param dst_path: destination path
             :param overwrite: if `True`, the resource will be overwritten if it already exists,
                               an error will be raised otherwise
+            :param fake_extension: if `True` appended to the file extension `.tmp` after a successful upload,
+                              the added extension is removed.
+                              Allows to work around the bug with slow uploading if the file has the extension
+                              *.zip, *.db, *.mp4, etc.
+            :param func_progress: `func(filesize, upload_size)` A callable function that is passed the file
+                              size and the size of the uploaded data
             :param fields: list of keys to be included in the response
             :param timeout: `float` or `tuple`, request timeout
             :param headers: `dict` or `None`, additional request headers


### PR DESCRIPTION
fake_extension: При выгрузке файлов с расширениями (*.zip, *.db, *mp4) существенно снижалась скорость, со стороны Yandex и они его не собираются фиксить. Если fake_extension=True то добавляется к пути выгрузки `.tmp` что обходит это ограничение, после выгрузки вызывается `move` c параметром оригинального расширения. Default: False

func_progress: Callback функция в которую передаётся размер выгружаемого файла и размер выгруженных данных. Возможно использовать для вывода прогресса выгрузки. `chunk_size` = размер файла / 100 частей. Шаг 1% Default: False

Добавлена зависимость aiofiles для асинхроного генератор в функции upload